### PR TITLE
ensures Core Add-On reports state changes from IonCore.js back to UI; UI now listens for changes

### DIFF
--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -242,8 +242,11 @@ module.exports = class IonCore {
     // we need set the value of that required pref.
     await browser.firefoxPrivilegedApi.setIonID(uuid);
 
-    // Finally send the ping.
+    // Send the ping.
     await this._dataCollection.sendEnrollmentPing();
+
+    // Update the frontend.
+    await this._sendStateUpdateToUI();
   }
 
   /**
@@ -267,6 +270,9 @@ module.exports = class IonCore {
 
     // Finally send the ping.
     await this._dataCollection.sendEnrollmentPing(studyAddonId);
+
+    // Update the frontend.
+    await this._sendStateUpdateToUI();
   }
 
   /**
@@ -343,6 +349,9 @@ module.exports = class IonCore {
 
     // Finally clear the list of studies user took part in.
     await this._storage.clearActivatedStudies();
+
+    // Update the frontend.
+    await this._sendStateUpdateToUI();
   }
 
   /**
@@ -466,12 +475,14 @@ module.exports = class IonCore {
    * ```
    */
   async _sendStateUpdateToUI() {
-    let isEnrolled = !!(await this._storage.getIonID());
-    let knownStudies = await this._availableStudies;
+    let enrolled = !!(await this._storage.getIonID());
+    let availableStudies = await this._availableStudies;
+    let activeStudies = await this._storage.getActivatedStudies();
 
     const newState = {
-      enrolled: isEnrolled,
-      availableStudies: knownStudies
+      enrolled,
+      availableStudies,
+      activeStudies,
     };
 
     // Send a message to the UI to update the list of studies.

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -25,17 +25,12 @@ module.exports = class IonCore {
 
     this._storage = new Storage();
     this._dataCollection = new DataCollection();
-    // Keep track of the task updating the state of available
-    // studies.
-    this._updateInstalledTask = null;
 
     // Asynchronously get the available studies. We don't need to wait
     // for this to finish, the UI can handle the wait.
-    // TODO: we don't really need "runUpdateINstall..." anymore, because
-    // we're synching up with the addon install/uninstall events.
     this._availableStudies =
       this._fetchAvailableStudies()
-          .then(studies => this.runUpdateInstalledStudiesTask(studies));
+          .then(studies => this._updateInstalledStudies(studies));
 
     this._connectionPort = null;
   }
@@ -388,37 +383,6 @@ module.exports = class IonCore {
     };
 
     return await browser.runtime.sendMessage(studyId, msg, {});
-  }
-
-  /**
-   * An utility function to run a task for updating the status
-   * of the available addons.
-   *
-   * Note that this is needed in order to prevent races between
-   * multiple callers of this functions (e.g. init, addon install,
-   * addon uninstall).
-   *
-   * @param {Array<Object>} studies
-   *        An array containing objects describing Ion studies.
-   * @returns {Promise(Array<Object>)} resolved with an array of studies
-   *          objects, or an empty array on failures. Each study object
-   *          has at least the `addon_id` and `ionInstalled` properties.
-   */
-  async runUpdateInstalledStudiesTask(studies) {
-    // We're already updating the state of the studies.
-    if (this._updateInstalledTask) {
-      return this._updateInstalledTask;
-    }
-
-    // Make sure to clear |_updateInstalledTask| once done.
-    let clear = studies => {
-      this._updateInstalledTask = null;
-      return studies;
-    };
-    // Since there's no archive cleaning task running, start it.
-    this._updateInstalledTask =
-      this._updateInstalledStudies(studies).then(clear, clear);
-    return this._updateInstalledTask;
   }
 
   /**

--- a/src/regions/StudyList.svelte
+++ b/src/regions/StudyList.svelte
@@ -11,20 +11,22 @@
   }
 </style>
 
-<div>
-  <h2>Current Studies</h2>
-  {#each $store.availableStudies as study}
-    <StudyCard
-      imageSrc={study.icons[64]}
-      dataCollectionDetails={study.dataCollectionDetails}
-      studyId={study.addon_id}
-      enrolled={$store.enrolled}
-      privacyPolicy={study.privacyPolicy.spec}
-      studyEnrolled={$store.activeStudies.includes(study.addon_id)}
-      on:enroll={() => store.updateStudyEnrollment(study.addon_id, !$store.activeStudies.includes(study.addon_id))}>
-      <span slot="name">{study.name}</span>
-      <span slot="authors">{study.authors.name}</span>
-      <span slot="description">{study.description}</span>
-    </StudyCard>
-  {/each}
-</div>
+{#if $store.activeStudies}
+  <div>
+    <h2>Current Studies</h2>
+    {#each $store.availableStudies as study}
+      <StudyCard
+        imageSrc={study.icons[64]}
+        dataCollectionDetails={study.dataCollectionDetails}
+        studyId={study.addon_id}
+        enrolled={$store.enrolled}
+        privacyPolicy={study.privacyPolicy.spec}
+        studyEnrolled={$store.activeStudies.includes(study.addon_id)}
+        on:enroll={() => store.updateStudyEnrollment(study.addon_id, !$store.activeStudies.includes(study.addon_id))}>
+        <span slot="name">{study.name}</span>
+        <span slot="authors">{study.authors.name}</span>
+        <span slot="description">{study.description}</span>
+      </StudyCard>
+    {/each}
+  </div>
+{/if}

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -186,10 +186,8 @@ describe('IonCore', function () {
       browser.storage.local.get.callsArgWith(1, {}).resolves();
       chrome.storage.local.get.yields({});
 
-      // Provide a valid study enrollment message.
-      await this.ionCore._handleMessage(
-        {type: "study-enrollment", data: { studyID: FAKE_STUDY_ID}}
-      );
+      // Attempt to enroll to a study.
+      await this.ionCore._enrollStudy(FAKE_STUDY_ID);
 
       // We expect to store the fake ion ID.
       telemetryMock.expects("setIonID").withArgs([FAKE_UUID]).calledOnce;
@@ -279,10 +277,8 @@ describe('IonCore', function () {
       chrome.storage.local.get.yields({});
       chrome.runtime.sendMessage.yields();
 
-      // Provide a valid study unenrollment message.
-      await this.ionCore._handleMessage(
-        {type: "study-unenrollment", data: { studyID: FAKE_STUDY_ID}}
-      );
+      // Unenroll from a study.
+      await this.ionCore._unenrollStudy(FAKE_STUDY_ID);
 
       // We expect to store the fake ion ID...
       telemetryMock.expects("setIonID").withArgs([FAKE_UUID]).calledOnce;

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -398,13 +398,13 @@ describe('IonCore', function () {
     });
   });
 
-  describe('runUpdateInstalledStudiesTask()', function () {
+  describe('_updateInstalledStudies()', function () {
     it('adds the ionInstalled property', async function () {
       // We don't expect any update task to be running now.
       assert.equal(this.ionCore._updateInstalledTask, null);
       // Kick off an update task.
       let studies =
-        await this.ionCore.runUpdateInstalledStudiesTask(FAKE_STUDY_LIST);
+        await this.ionCore._updateInstalledStudies(FAKE_STUDY_LIST);
       assert.equal(studies.length, 2);
       // Check that the FAKE_STUDY_ID is marked as installed (as per
       // our fake data, see the beginning of this file).


### PR DESCRIPTION
@Dexterp37 Sorry if I pushed to another branch in some weird way; the following changes to your branch should enable the frontend and make sure it all stays updated with background store changes.

I believe this might break the tests. Apologies. i can take another look in the morning. I don't think it's anything that can't be fixed fairly easy. The issue is primarily with `_handleMessage`. This branch adds `this._sendStateToUI` at the end of each of the functions in `_handleMessage`. We need this to report back to the UI after those important state changes.